### PR TITLE
Add Java version for compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- or whatever version you use -->
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <finalName>pizza-finder</finalName>


### PR DESCRIPTION
That avoids compilation problems when running commands such as mvn
package without further arguments.
